### PR TITLE
Split debug symbols into separate debug directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Cross-compiling from Linux
 You will need:
 
 - MinGW-w64 gcc and g++ for the target architecture (`i686` or `x86_64`)
+- MinGW-w64 Binutils >= 2.25
 - NASM
 - OpenJDK
 - Apache Ant

--- a/build.sh
+++ b/build.sh
@@ -380,10 +380,12 @@ build_one() {
     pushd "$builddir" >/dev/null
     case "$1" in
     zlib)
+        # Don't strip binaries during build
         make -f win32/Makefile.gcc $parallel \
                 PREFIX="${build_host}-" \
                 CFLAGS="${cppflags} ${cflags}" \
                 LDFLAGS="${ldflags}" \
+                STRIP="true" \
                 all
         if [ "$can_test" = yes ] ; then
             make -f win32/Makefile.gcc \
@@ -444,6 +446,8 @@ build_one() {
         make install
         ;;
     iconv)
+        # Don't strip DLL during build
+        sed -i 's/-Wl,-s //' Makefile
         make \
                 CC="${build_host}-gcc" \
                 AR="${build_host}-ar" \

--- a/build.sh
+++ b/build.sh
@@ -739,14 +739,6 @@ probe() {
     cxxflags="${cflags}"
     ldflags="-static-libgcc -Wl,--enable-auto-image-base -Wl,--dynamicbase -Wl,--nxcompat -Wl,--build-id"
 
-    if ${build_host}-ld --help | grep -q -- --insert-timestamp ; then
-        # Disable deterministic build feature in GNU ld 2.24 (disabled
-        # by default in 2.25) which breaks detection of updated libraries
-        # by bound executables
-        # https://sourceware.org/bugzilla/show_bug.cgi?id=16887
-        ldflags="${ldflags} -Wl,--insert-timestamp"
-    fi
-
     case "$build_system" in
     *-*-cygwin)
         # Windows

--- a/build.sh
+++ b/build.sh
@@ -737,7 +737,7 @@ probe() {
     cppflags="-D_FORTIFY_SOURCE=2"
     cflags="-O2 -g -mms-bitfields -fexceptions -ftree-vectorize ${arch_cflags}"
     cxxflags="${cflags}"
-    ldflags="-static-libgcc -Wl,--enable-auto-image-base -Wl,--dynamicbase -Wl,--nxcompat"
+    ldflags="-static-libgcc -Wl,--enable-auto-image-base -Wl,--dynamicbase -Wl,--nxcompat -Wl,--build-id"
 
     if ${build_host}-ld --help | grep -q -- --insert-timestamp ; then
         # Disable deterministic build feature in GNU ld 2.24 (disabled


### PR DESCRIPTION
Fixes #5.

Remaining issues:

- [ ] Wait until MinGW Binutils 2.25 lands in Cygwin.
- [ ] GDB [fails to automatically locate the symbol files](https://sourceware.org/ml/gdb/2015-03/msg00008.html) even when the `debug-file-directory` is correctly set.