### PR TITLE
Dockerfile.builder: add bzip2

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
 FROM registry.fedoraproject.org/fedora:36
-RUN dnf -y install ant cmake gcc gettext git-core glib2-devel java meson \
-    mingw{32,64}-gcc-c++ nasm wget zip && \
+RUN dnf -y install ant bzip2 cmake gcc gettext git-core glib2-devel java \
+    meson mingw{32,64}-gcc-c++ nasm wget zip && \
     dnf clean all


### PR DESCRIPTION
We'll need it in a subsequent PR, but this needs to land first so the new container image can be used in CI.