### PR TITLE
Fixes for containerized build on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of its dependencies, using MinGW-w64.
 run the build script.  To pull the container image and use it to run a
 build:
 
-    docker run -ti --rm -v .:/work -w /work \
+    docker run -ti --rm -v $PWD:/work -w /work \
         ghcr.io/openslide/winbuild-builder ./build.sh bdist
 
 ## Cross-compiling from Linux

--- a/build.sh
+++ b/build.sh
@@ -580,7 +580,8 @@ build_one() {
         make install
         ;;
     ffi)
-        do_configure
+        do_configure \
+                --disable-builddir
         make $parallel
         if [ "$can_test" = yes ] ; then
             make check


### PR DESCRIPTION
Reported in https://github.com/openslide/openslide-winbuild/issues/36#issuecomment-1177314723.