### PR TITLE
Skip `longjmp()` SEH unwind in 64-bit build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -780,6 +780,31 @@ probe() {
     cxxflags="${cflags}"
     ldflags="-L${root}/lib -static-libgcc -Wl,--enable-auto-image-base -Wl,--dynamicbase -Wl,--nxcompat -lssp"
 
+    # On 64-bit Windows, MinGW passes a frame pointer to _setjmp so longjmp
+    # can do a SEH unwind.  This seems to work when the caller is also built
+    # with MinGW, but sometimes crashes with STATUS_BAD_STACK when the
+    # caller is built with MSVC; it appears that this is a longstanding
+    # MinGW issue.  In 64-bit builds, override setjmp() to pass a NULL frame
+    # pointer to skip the SEH unwind.  Our uses of setjmp/longjmp are all in
+    # libpng/libjpeg error handling, which isn't expecting to do any cleanup
+    # in intermediate stack frames, so this should be fine.
+    # https://github.com/openslide/openslide-winbuild/issues/47
+    mkdir -p "${root}/include"
+    cat > "${root}/include/setjmp.h" <<EOF
+#ifndef OPENSLIDE_SETJMP_H
+#define OPENSLIDE_SETJMP_H
+
+/* gcc extension */
+#include_next <setjmp.h>
+
+#ifdef __x86_64__
+#undef setjmp
+#define setjmp(buf) _setjmp(buf, NULL)
+#endif
+
+#endif
+EOF
+
     # Ensure Wine is not run via binfmt_misc, since some packages
     # attempt to run programs after building them.
     for hdr in PE MZ

--- a/build.sh
+++ b/build.sh
@@ -314,10 +314,10 @@ do_configure() {
             PKG_CONFIG_LIBDIR="${root}/lib/pkgconfig" \
             PKG_CONFIG_PATH= \
             CC="${build_host}-gcc -static-libgcc" \
-            CPPFLAGS="${cppflags} -I${root}/include" \
+            CPPFLAGS="${cppflags}" \
             CFLAGS="${cflags}" \
             CXXFLAGS="${cxxflags}" \
-            LDFLAGS="-L${root}/lib ${ldflags}" \
+            LDFLAGS="${ldflags}" \
             "$@"
 }
 
@@ -348,9 +348,9 @@ EOF
             -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY \
             -DCMAKE_C_FLAGS="${cppflags} ${cflags}" \
             -DCMAKE_CXX_FLAGS="${cppflags} ${cxxflags}" \
-            -DCMAKE_EXE_LINKER_FLAGS="-L${root}/lib ${ldflags}" \
-            -DCMAKE_SHARED_LINKER_FLAGS="-L${root}/lib ${ldflags}" \
-            -DCMAKE_MODULE_LINKER_FLAGS="-L${root}/lib ${ldflags}" \
+            -DCMAKE_EXE_LINKER_FLAGS="${ldflags}" \
+            -DCMAKE_SHARED_LINKER_FLAGS="${ldflags}" \
+            -DCMAKE_MODULE_LINKER_FLAGS="${ldflags}" \
             "$@" \
             .
 }
@@ -366,10 +366,10 @@ do_meson_setup() {
     cat > cross.ini <<EOF
 [built-in options]
 prefix = '${root}'
-c_args = $(make_meson_list "${cppflags} -I${root}/include ${cflags}")
-c_link_args = $(make_meson_list "-L${root}/lib ${ldflags}")
-cpp_args = $(make_meson_list "${cppflags} -I${root}/include ${cxxflags}")
-cpp_link_args = $(make_meson_list "-L${root}/lib ${ldflags}")
+c_args = $(make_meson_list "${cppflags} ${cflags}")
+c_link_args = $(make_meson_list "${ldflags}")
+cpp_args = $(make_meson_list "${cppflags} ${cxxflags}")
+cpp_link_args = $(make_meson_list "${ldflags}")
 pkg_config_path = ''
 
 [properties]
@@ -775,10 +775,10 @@ probe() {
         exit 1
     fi
 
-    cppflags=""
+    cppflags="-I${root}/include"
     cflags="-O2 -g -mms-bitfields -fexceptions -ftree-vectorize ${arch_cflags}"
     cxxflags="${cflags}"
-    ldflags="-static-libgcc -Wl,--enable-auto-image-base -Wl,--dynamicbase -Wl,--nxcompat -lssp"
+    ldflags="-L${root}/lib -static-libgcc -Wl,--enable-auto-image-base -Wl,--dynamicbase -Wl,--nxcompat -lssp"
 
     # Ensure Wine is not run via binfmt_misc, since some packages
     # attempt to run programs after building them.


### PR DESCRIPTION
On 64-bit Windows, MinGW passes a frame pointer to `_setjmp` so `longjmp` can do a SEH unwind.  This seems to work when the caller is also built with MinGW, but sometimes crashes with `STATUS_BAD_STACK` when the caller is built with MSVC; it appears that this is a longstanding MinGW issue.  In 64-bit builds, override `setjmp()` to pass a `NULL` frame pointer to skip
the SEH unwind.  Our uses of `setjmp`/`longjmp` are all in libpng/libjpeg error handling, which isn't expecting to do any cleanup in intermediate stack frames, so this should be fine.

Fixes https://github.com/openslide/openslide-winbuild/issues/47.