### PR TITLE
workflows: have PR CI build OpenSlide main with `-Werror`

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,3 +41,4 @@ jobs:
       openslide_winbuild_repo: ${{ github.repository }}
       openslide_winbuild_ref: ${{ github.ref }}
       pkgver: ${{ needs.setup.outputs.pkgver }}-git
+      werror: true


### PR DESCRIPTION
If an openslide-winbuild change introduces new OpenSlide build warnings, we should know about it at the PR stage.

However, don't build the OpenSlide stable release with `-Werror`, since compiler warnings can be added over time and there's nothing we can do about it in existing releases.