### PR TITLE
Dockerfile.builder: bump to Fedora 37

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:36
+FROM registry.fedoraproject.org/fedora:37
 RUN dnf -y install ant bzip2 cmake gcc gettext git-core glib2-devel java \
     meson mingw{32,64}-gcc-c++ nasm wget zip && \
     dnf clean all


### PR DESCRIPTION
Smoke-tested locally.

Hold until Fedora 37 is released.