### PR TITLE
Dockerfile.builder: add xz, drop Ant

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
 FROM registry.fedoraproject.org/fedora:37
 RUN dnf -y install ant bzip2 cmake gcc gettext git-core glib2-devel java \
-    meson mingw{32,64}-gcc-c++ nasm wget zip && \
+    meson mingw{32,64}-gcc-c++ nasm wget xz zip && \
     dnf clean all

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
 FROM registry.fedoraproject.org/fedora:37
-RUN dnf -y install ant bzip2 cmake gcc gettext git-core glib2-devel java \
+RUN dnf -y install bzip2 cmake gcc gettext git-core glib2-devel java \
     meson mingw{32,64}-gcc-c++ nasm wget xz zip && \
     dnf clean all


### PR DESCRIPTION
Apparently there was a package dependency change in the latest build and xz dropped out.  Ant was only used for OpenSlide Java, which has switched to Meson.