### PR TITLE
Dockerfile.builder: re-add `javac`

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
 FROM registry.fedoraproject.org/fedora:37
-RUN dnf -y install bzip2 cmake gcc gettext git-core glib2-devel java \
+RUN dnf -y install bzip2 cmake gcc gettext git-core glib2-devel java-devel \
     meson mingw{32,64}-gcc-c++ nasm wget xz zip && \
     dnf clean all


### PR DESCRIPTION
Ant was pulling it in, but we need to be explicit now.

Fixes #67.