### PR TITLE
Dockerfile.builder: install Meson 1.0.0 from PyPI

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,6 @@
 FROM registry.fedoraproject.org/fedora:37
 RUN dnf -y install bzip2 cmake gcc gettext git-core glib2-devel java-devel \
-    meson mingw{32,64}-gcc-c++ nasm wget xz zip && \
+    mingw{32,64}-gcc-c++ nasm ninja-build python3-pip wget xz zip && \
     dnf clean all
+# in Fedora 38 we can switch back to the meson RPM
+RUN pip install meson==1.0.0 && rm -r /root/.cache/pip


### PR DESCRIPTION
The libffi wrap requires Meson 0.64 and Fedora 37 has 0.63.

Revert this when switching to Fedora 38.