### PR TITLE
workflows: conditionalize autoreconf of OpenSlide

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -98,11 +98,13 @@ jobs:
         if: inputs.openslide_repo != ''
         working-directory: override/openslide
         run: |
-          autoreconf -i
-          # Generate openslide-tables.c
-          ./configure
-          make -j4
-          make distclean
+          if [ -e configure.ac ]; then
+              autoreconf -i
+              # Generate openslide-tables.c
+              ./configure
+              make -j4
+              make distclean
+          fi
       - name: Collect overrides
         if: inputs.openslide_repo != '' || inputs.openslide_java_repo != ''
         run: tar cf overrides.tar override


### PR DESCRIPTION
In order to ratchet the Meson conversion into OpenSlide, we need to temporarily conditionalize the `autoreconf` run.