### PR TITLE
workflows: use `gh` command to create releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,15 +40,15 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ needs.stable.outputs.artifact }}
-      - name: Generate release notes
+      - name: Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           unzip "${{ needs.stable.outputs.artifact }}/openslide-win32-${{ needs.setup.outputs.pkgver }}.zip"
           grep OpenSlide "openslide-win32-${{ needs.setup.outputs.pkgver }}/VERSIONS.txt" |
-              sed -E 's/ +/ /g' > notes.md
-      - name: Create release
-        uses: softprops/action-gh-release@v0.1.14
-        with:
-          name: Windows build ${{ needs.setup.outputs.pkgver }}
-          body_path: notes.md
-          files: "${{ needs.stable.outputs.artifact }}/*"
-          fail_on_unmatched_files: true
+              sed -E 's/ +/ /g' |
+              gh release create --latest --notes-file - --verify-tag \
+                  --repo "${{ github.repository }}" \
+                  --title "Windows build ${{ needs.setup.outputs.pkgver }}" \
+                  "${{ github.ref_name }}" \
+                  "${{ needs.stable.outputs.artifact }}/"*


### PR DESCRIPTION
`action-gh-release` uses the deprecated `set-output` command and appears to be unmaintained.  Use `gh`, which is pre-installed on the runners.