### PR TITLE
Pin libdicom to a commit

### DIFF
--- a/meson/subprojects/libdicom.wrap
+++ b/meson/subprojects/libdicom.wrap
@@ -4,7 +4,7 @@
 # NOTE: temporary fork for now
 # https://github.com/openslide/openslide-winbuild/issues/82
 url = https://github.com/jcupitt/libdicom.git
-revision = main
+revision = 2f3c8ff54ab7238f7aa4faba96ae41752d505769
 depth = 1
 
 # this is needed by meson_wrap_key() to get the directory we clone to


### PR DESCRIPTION
Use the commit that's pinned in OpenSlide's copy of the wrap.  The libdicom main branch currently has breaking changes in it.