### PR TITLE
Ship slidetool instead of openslide-* programs if available

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -181,11 +181,17 @@ jobs:
           for bits in 32 64; do
               echo "======== ${bits}-bit ========"
               cd "${GITHUB_WORKSPACE}/openslide-win${bits}-${{ inputs.pkgver }}/bin"
-              OPENSLIDE_DEBUG=? ./openslide-show-properties.exe 2> conftest ||:
+              if [ -e slidetool.exe ]; then
+                  showprops="./slidetool.exe property list"
+              else
+                  # OpenSlide 3.4.1
+                  showprops="./openslide-show-properties.exe"
+              fi
+              OPENSLIDE_DEBUG=? $showprops 2> conftest ||:
               if ! grep -q "  synthetic  " conftest; then
                   # OpenSlide 3.4.1
                   echo "Smoke test not supported in this OpenSlide version"
                   continue
               fi
-              OPENSLIDE_DEBUG=synthetic ./openslide-show-properties.exe ""
+              OPENSLIDE_DEBUG=synthetic $showprops ""
           done

--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ openslide_java_licenses="COPYING.LESSER"
 # Build artifacts
 ssp_artifacts="libssp-0.dll"
 winpthreads_artifacts="libwinpthread-1.dll"
-openslide_artifacts="libopenslide-0.dll openslide-quickhash1sum.exe openslide-show-properties.exe openslide-write-png.exe"
+openslide_artifacts="libopenslide-0.dll openslide-quickhash1sum.exe openslide-show-properties.exe openslide-write-png.exe slidetool.exe"
 openslide_java_artifacts="openslide-jni.dll openslide.jar"
 
 # Update-checking URLs
@@ -285,6 +285,11 @@ bdist() {
         fi
         for artifact in $(expand ${package}_artifacts)
         do
+            if [ "${artifact}" = slidetool.exe -a \
+                    ! -e "${root}/bin/${artifact}" ]; then
+                # Allow missing slidetool.exe until next OpenSlide release
+                continue
+            fi
             if [ "${artifact}" != "${artifact%.dll}" -o \
                     "${artifact}" != "${artifact%.exe}" ] ; then
                 echo "Stripping ${artifact}..."
@@ -327,6 +332,10 @@ bdist() {
                 cp "${srcdir}/README.md" "${zipdir}/"
             else
                 cp "${srcdir}/README.txt" "${zipdir}/"
+            fi
+            if [ -e "${zipdir}/bin/slidetool.exe" ]; then
+                # If slidetool is present, drop the redundant legacy programs
+                rm "${zipdir}/bin/openslide-"*".exe"*
             fi
         fi
         printf "%-30s %s\n" "$(expand ${package}_name)" \


### PR DESCRIPTION
Each program costs 1.5 - 2 MB in the binary ZIP.  slidetool implements the functionality of all of them, and can also be used directly as any of the openslide-* programs by copying/renaming the binary.

For https://github.com/openslide/openslide/pull/465.