### PR TITLE
Update libdicom

### DIFF
--- a/meson/subprojects/libdicom.wrap
+++ b/meson/subprojects/libdicom.wrap
@@ -4,7 +4,7 @@
 # NOTE: temporary fork for now
 # https://github.com/openslide/openslide-winbuild/issues/82
 url = https://github.com/jcupitt/libdicom.git
-revision = 6dfb2b870143e37b4f5620b59e12b3dbefb40c8f
+revision = 532879925086b3d8cfc7b3c090af96fa2ea6589a
 depth = 1
 
 # this is needed by meson_wrap_key() to get the directory we clone to


### PR DESCRIPTION
CI will fail due to a breaking API change.