### PR TITLE
Commit `packagecache/CACHEDIR.TAG` to repo

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -240,10 +240,6 @@ sdist() {
     local package file zipdir
     zipdir="openslide-winbuild-${pkgver}"
     rm -rf "${zipdir}"
-    # Ideally Meson would create CACHEDIR.TAG files in packagecache and in
-    # the unpacked subproject directories.  We can at least do the former.
-    # https://github.com/mesonbuild/meson/issues/12103
-    tag_cachedir meson/subprojects/packagecache
     meson subprojects download --sourcedir meson
     mkdir -p "${zipdir}/meson/subprojects/packagecache"
     for package in $packages
@@ -283,8 +279,6 @@ bdist() {
     fi
 
     tag_cachedir "${build_bits}"
-    # https://github.com/mesonbuild/meson/issues/12103
-    tag_cachedir meson/subprojects/packagecache
 
     (
         override_lock

--- a/meson/subprojects/packagecache/CACHEDIR.TAG
+++ b/meson/subprojects/packagecache/CACHEDIR.TAG
@@ -1,0 +1,3 @@
+Signature: 8a477f597d28d172789f06886806bc55
+# This file is a cache directory tag committed to the openslide-winbuild repo.
+# For information about cache directory tags, see https://bford.info/cachedir/


### PR DESCRIPTION
The tag is mainly needed when the working directory is a Git checkout, since the package cache can accumulate source tarballs over time.  Commit it directly rather than writing the file at runtime.

We don't copy the tag into the sdist zip.  When the working directory comes from an sdist zip, the `packagecache` files won't change further, and arguably shouldn't be excluded from archiving because they're canonically part of the source tree at that point.

We still don't create `CACHEDIR.TAG` files in the unpacked subproject directories.  Leave that to Meson to implement for now.