### PR TITLE
Dockerfile.builder: update to Fedora 39

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:38
+FROM registry.fedoraproject.org/fedora:39
 RUN dnf -y install bzip2 gcc gettext git-core glib2-devel java-devel \
     meson mingw{32,64}-gcc-c++ nasm wget xz zip && \
     dnf clean all


### PR DESCRIPTION
It's in beta, but we want the updated MinGW runtime.