### PR TITLE
Convert `VERSIONS.txt` to Markdown table; add toolchain versions; use in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,10 +45,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           unzip "${{ needs.stable.outputs.artifact }}/openslide-win32-${{ needs.setup.outputs.pkgver }}.zip"
-          grep OpenSlide "openslide-win32-${{ needs.setup.outputs.pkgver }}/VERSIONS.txt" |
-              sed -E 's/ +/ /g' |
-              gh release create --latest --notes-file - --verify-tag \
-                  --repo "${{ github.repository }}" \
-                  --title "Windows build ${{ needs.setup.outputs.pkgver }}" \
-                  "${{ github.ref_name }}" \
-                  "${{ needs.stable.outputs.artifact }}/"*
+          gh release create --latest --verify-tag \
+              --repo "${{ github.repository }}" \
+              --title "Windows build ${{ needs.setup.outputs.pkgver }}" \
+              --notes-file "openslide-win32-${{ needs.setup.outputs.pkgver }}/VERSIONS.md" \
+              "${{ github.ref_name }}" \
+              "${{ needs.stable.outputs.artifact }}/"*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -175,6 +175,9 @@ jobs:
           for bits in 32 64; do
               unzip "${{ needs.sdist.outputs.artifact }}/openslide-win${bits}-${{ inputs.pkgver }}.zip"
           done
+      - name: Report package versions
+        shell: bash
+        run: cat "openslide-win32-${{ inputs.pkgver }}/VERSIONS.md" >> $GITHUB_STEP_SUMMARY
       - name: Smoke test
         shell: bash
         run: |

--- a/build.sh
+++ b/build.sh
@@ -261,6 +261,13 @@ sdist() {
     rm -r "${zipdir}"
 }
 
+log_version() {
+    # $1 = zipdir
+    # $2 = package
+    # $3 = version
+    printf "| %-20s | %-53s |\n" "$2" "$3" >> "$1/VERSIONS.md"
+}
+
 bdist() {
     # Build binary distribution
     local package name srcdir licensedir zipdir prev_ver_suffix
@@ -285,6 +292,17 @@ bdist() {
     zipdir="openslide-win${build_bits}-${pkgver}"
     rm -rf "${zipdir}"
     mkdir -p "${zipdir}/bin"
+    log_version "${zipdir}" "Software" "Version"
+    log_version "${zipdir}" "--------" "-------"
+    for package in $packages
+    do
+        case "${package}" in
+        openslide|openslide_java)
+            log_version "${zipdir}" "**$(expand ${package}_name)**" \
+                    "**$(meson_wrap_version ${package})**"
+            ;;
+        esac
+    done
     for package in $packages
     do
         if [ -d "override/${package}" ] ;then
@@ -346,9 +364,10 @@ bdist() {
                 # If slidetool is present, drop the redundant legacy programs
                 rm "${zipdir}/bin/openslide-"*".exe"*
             fi
+        elif [ "$package" != openslide_java ]; then
+            log_version "${zipdir}" "$(expand ${package}_name)" \
+                    "$(meson_wrap_version ${package})"
         fi
-        printf "%-30s %s\n" "$(expand ${package}_name)" \
-                "$(meson_wrap_version ${package})" >> "${zipdir}/VERSIONS.txt"
     done
     rm -f "${zipdir}.zip"
     zip -r "${zipdir}.zip" "${zipdir}"


### PR DESCRIPTION
List OpenSlide and OpenSlide Java in bold at the top of the table, since they're the most relevant pieces.  Add the versions of MinGW-w64, GCC, and Binutils in italics at the bottom, since they affect the build but are not directly included in it.

Use the table as the GitHub release description for stable releases, and also include it on the summary page of CI runs.

<details>
<summary>Example output</summary>

| Software             | Version                                               |
| --------             | -------                                               |
| **OpenSlide**        | **3.4.1**                                             |
| **OpenSlide Java**   | **0.12.3**                                            |
| winpthreads          | 11.0.1                                                |
| zlib                 | 1.3-2                                                 |
| libpng               | 1.6.40-1                                              |
| libjpeg-turbo        | 3.0.0-3                                               |
| libtiff              | 4.6.0-1                                               |
| OpenJPEG             | 2.5.0-1                                               |
| SQLite               | 3.43.1-1                                              |
| proxy-libintl        | 0.4                                                   |
| libffi               | 3.4.4-2                                               |
| PCRE2                | 10.42-5                                               |
| glib                 | 2.76.5-1                                              |
| gdk-pixbuf           | 2.42.10                                               |
| pixman               | 0.42.2                                                |
| cairo                | 1.17.8-1                                              |
| libxml2              | 2.11.5-1                                              |
| uthash               | 2.3.0                                                 |
| libdicom             | libdicom                                              |
| _MinGW-w64_          | _11.0.0_                                              |
| _GCC_                | _13.2.1 20230728 (Fedora MinGW 13.2.1-5.fc39)_        |
| _Binutils_           | _2.40-4.fc39_                                         |
</details>