### PR TITLE
Switch builder container to Gentoo

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,10 +5,10 @@ name: Container
 on:
   push:
     branches: [main]
-    paths: [Dockerfile.builder]
+    paths: [builder/*]
   pull_request:
     branches: [main]
-    paths: [Dockerfile.builder]
+    paths: [builder/*]
   workflow_dispatch:
   # openslide/builds invokes this from a scheduled build
   workflow_call:
@@ -34,7 +34,7 @@ jobs:
           repository: ${{ github.repository_owner }}/openslide-winbuild
       - name: Build container
         run: |
-          podman build -t $CONTAINER_IMAGE -f Dockerfile.builder .
+          podman build -t $CONTAINER_IMAGE builder
       - name: Push container
         if: github.event_name != 'pull_request'
         run: |

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,4 +1,0 @@
-FROM registry.fedoraproject.org/fedora:39
-RUN dnf -y install bzip2 gcc gettext git-core glib2-devel java-devel \
-    meson mingw{32,64}-gcc-c++ nasm wget xz zip && \
-    dnf clean all

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ of its dependencies, using MinGW-w64.
 
 ## Building
 
-`Dockerfile.builder` defines a container with the dependencies needed to
-run the build script.  To pull the container image and use it to run a
-build:
+The `builder` directory defines a container image with the dependencies
+needed to run the build script.  To pull the container image and use it to
+run a build:
 
     docker run -ti --rm -v $PWD:/work -w /work \
         ghcr.io/openslide/winbuild-builder ./build.sh bdist

--- a/build.sh
+++ b/build.sh
@@ -258,8 +258,10 @@ sdist() {
                     "${zipdir}/meson/subprojects/packagefiles/"
         done
     done
-    mkdir -p "${zipdir}/meson/include"
-    cp build.sh Dockerfile.builder README.md COPYING.LESSER "${zipdir}/"
+    mkdir -p "${zipdir}/builder" "${zipdir}/meson/include"
+    cp build.sh README.md COPYING.LESSER "${zipdir}/"
+    cp builder/Dockerfile builder/package.accept_keywords builder/package.use \
+            builder/repos.conf "${zipdir}/builder/"
     cp meson/cross-win32.ini meson/cross-win64.ini \
             meson/meson.build meson/meson_options.txt "${zipdir}/meson/"
     cp meson/include/setjmp.h "${zipdir}/meson/include/"

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/gentoo/stage3:latest
+RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
+COPY package.accept_keywords /etc/portage/package.accept_keywords/cross
+COPY package.use /etc/portage/package.use/cross
+RUN mkdir -p /var/db/repos/crossdev/{profiles,metadata} && echo crossdev > /var/db/repos/crossdev/profiles/repo_name && echo 'masters = gentoo' > /var/db/repos/crossdev/metadata/layout.conf && chown -R portage:portage /var/db/repos/crossdev
+COPY repos.conf /etc/portage/repos.conf/crossdev.conf
+COPY --from=docker.io/gentoo/portage:latest /var/db/repos/gentoo /var/db/repos/gentoo
+RUN emerge app-arch/zip app-portage/gentoolkit dev-lang/nasm \
+    dev-java/openjdk-bin dev-util/glib-utils dev-vcs/git sys-devel/crossdev && \
+    rm /var/cache/distfiles/*
+RUN crossdev -t i686-w64-mingw32 && \
+    crossdev -t x86_64-w64-mingw32 && \
+    rm /var/cache/distfiles/*

--- a/builder/package.accept_keywords
+++ b/builder/package.accept_keywords
@@ -1,0 +1,4 @@
+cross-i686-w64-mingw32/binutils:2.41 ~amd64
+cross-x86_64-w64-mingw32/binutils:2.41 ~amd64
+cross-i686-w64-mingw32/gcc:13 ~amd64
+cross-x86_64-w64-mingw32/gcc:13 ~amd64

--- a/builder/package.use
+++ b/builder/package.use
@@ -1,0 +1,8 @@
+dev-java/openjdk-bin headless-awt
+dev-libs/glib -elf -mime
+dev-vcs/git -perl
+
+cross-i686-w64-mingw32/gcc -fortran
+cross-x86_64-w64-mingw32/gcc -fortran
+cross-i686-w64-mingw32/mingw64-runtime default-ucrt
+cross-x86_64-w64-mingw32/mingw64-runtime default-ucrt

--- a/builder/repos.conf
+++ b/builder/repos.conf
@@ -1,0 +1,5 @@
+[crossdev]
+location = /var/db/repos/crossdev
+priority = 10
+masters = gentoo
+auto-sync = no


### PR DESCRIPTION
A Gentoo-based container is significantly larger and takes much longer to build, but gives us more control over the toolchain.  This allows us to do three things:

- Specify the GCC and Binutils versions we want.
- Switch from msvcrt to the UCRT in both 32-bit and 64-bit builds.
- Switch the toolchain from pthreads-based thread intrinsics to win32-based ones so we can drop the winpthreads DLL.

The new builder container doesn't even include winpthreads, so we'll notice if something tries to use it.  A common Meson packaging bug is to introduce an unconditional `threads` dependency in libraries that can use win32 threading primitives directly.

Fixes #48.