### PR TITLE
workflows: expect builder container repo/digest as parameter

### DIFF
--- a/.github/workflows/find-container-digest/action.yml
+++ b/.github/workflows/find-container-digest/action.yml
@@ -1,0 +1,30 @@
+# Action to convert a Docker image ref of the builder container to
+# a repo and image digest
+
+name: Find builder container digest
+description: Get repo and image digest of the OpenSlide builder container
+inputs:
+  builder_image:
+    description: Docker image reference of the builder container
+    required: false
+    type: string
+outputs:
+  builder_repo_and_digest:
+    description: Docker repo and image digest of the builder container
+    value: ${{ steps.find.outputs.builder_repo_and_digest }}
+
+runs:
+  using: composite
+  steps:
+    - id: find
+      shell: bash
+      run: |
+        repo=$(cut -f1 -d: <<<"${{ inputs.builder_image }}")
+        repo="${repo:-ghcr.io/openslide/winbuild-builder}"
+        label=$(cut -f2 -d: <<<"${{ inputs.builder_image }}")
+        label="${label:-latest}"
+        digest=$(skopeo inspect "docker://${repo}:${label}" | jq -r .Digest)
+        ref="${repo}@${digest}"
+        echo "Builder container:"
+        echo "${ref}"
+        echo "builder_repo_and_digest=${ref}" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,14 @@ jobs:
     name: Set up
     runs-on: ubuntu-latest
     outputs:
+      builder_repo_and_digest: ${{ steps.find.outputs.builder_repo_and_digest }}
       pkgver: ${{ steps.params.outputs.pkgver }}
     steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Find builder container digest
+        id: find
+        uses: ./.github/workflows/find-container-digest
       - name: Calculate parameters
         id: params
         run: echo "pkgver=main-$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
@@ -26,6 +32,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/windows.yml
     with:
+      builder_repo_and_digest: ${{ needs.setup.outputs.builder_repo_and_digest }}
       openslide_winbuild_repo: ${{ github.repository }}
       openslide_winbuild_ref: ${{ github.ref }}
       pkgver: ${{ needs.setup.outputs.pkgver }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,8 +14,14 @@ jobs:
     name: Set up
     runs-on: ubuntu-latest
     outputs:
+      builder_repo_and_digest: ${{ steps.find.outputs.builder_repo_and_digest }}
       pkgver: ${{ steps.params.outputs.pkgver }}
     steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Find builder container digest
+        id: find
+        uses: ./.github/workflows/find-container-digest
       - name: Calculate parameters
         id: params
         run: echo "pkgver=pr-${{ github.event.number }}.${{ github.run_number }}.${{ github.run_attempt }}-$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT
@@ -25,6 +31,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/windows.yml
     with:
+      builder_repo_and_digest: ${{ needs.setup.outputs.builder_repo_and_digest }}
       openslide_winbuild_repo: ${{ github.repository }}
       openslide_winbuild_ref: ${{ github.ref }}
       pkgver: ${{ needs.setup.outputs.pkgver }}-stable
@@ -34,6 +41,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/windows.yml
     with:
+      builder_repo_and_digest: ${{ needs.setup.outputs.builder_repo_and_digest }}
       openslide_repo: openslide/openslide
       openslide_ref: main
       openslide_java_repo: openslide/openslide-java

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,14 @@ jobs:
     name: Set up
     runs-on: ubuntu-latest
     outputs:
+      builder_repo_and_digest: ${{ steps.find.outputs.builder_repo_and_digest }}
       pkgver: ${{ steps.params.outputs.pkgver }}
     steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+      - name: Find builder container digest
+        id: find
+        uses: ./.github/workflows/find-container-digest
       - name: Calculate parameters
         id: params
         run: echo "pkgver=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
@@ -27,6 +33,7 @@ jobs:
     needs: setup
     uses: ./.github/workflows/windows.yml
     with:
+      builder_repo_and_digest: ${{ needs.setup.outputs.builder_repo_and_digest }}
       openslide_winbuild_repo: ${{ github.repository }}
       openslide_winbuild_ref: ${{ github.ref }}
       pkgver: ${{ needs.setup.outputs.pkgver }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,6 +5,11 @@ name: Windows
 on:
   workflow_call:
     inputs:
+      builder_repo_and_digest:
+        # Use ./find-container-digest action to get this
+        description: Docker repo and image digest of the builder container
+        required: true
+        type: string
       openslide_repo:
         description: Override OpenSlide with this repo
         required: false
@@ -52,7 +57,7 @@ jobs:
   sdist:
     name: Build source zip
     runs-on: ubuntu-latest
-    container: ghcr.io/openslide/winbuild-builder:latest
+    container: ${{ inputs.builder_repo_and_digest }}
     outputs:
       artifact: ${{ steps.prep.outputs.artifact }}
       version_suffix: ${{ steps.prep.outputs.version_suffix }}
@@ -119,7 +124,7 @@ jobs:
     name: Build
     needs: sdist
     runs-on: ubuntu-latest
-    container: ghcr.io/openslide/winbuild-builder:latest
+    container: ${{ inputs.builder_repo_and_digest }}
     strategy:
       matrix:
         bits: [32, 64]


### PR DESCRIPTION
Expect the container repo and image digest as a parameter to the `windows` workflow.  This allows the caller (particularly the nightly builder) to exercise full control over the container image, and ensures that every job in the workflow uses the same image.

Add a `find-container-digest` action that can be invoked from callers' setup jobs to compute the parameter.

This is a breaking change for callers of the `windows` workflow in other repos.