### PR TITLE
Check for stray exported symbols in OpenSlide DLL

### DIFF
--- a/meson/cross-win32.ini
+++ b/meson/cross-win32.ini
@@ -17,6 +17,7 @@ c = 'i686-w64-mingw32-gcc'
 cpp = 'i686-w64-mingw32-g++'
 ld = 'i686-w64-mingw32-ld'
 objcopy = 'i686-w64-mingw32-objcopy'
+objdump = 'i686-w64-mingw32-objdump'
 # Fedora's ${build_host}-pkg-config clobbers search paths; avoid it
 pkgconfig = 'pkg-config'
 strip = 'i686-w64-mingw32-strip'

--- a/meson/cross-win64.ini
+++ b/meson/cross-win64.ini
@@ -17,6 +17,7 @@ c = 'x86_64-w64-mingw32-gcc'
 cpp = 'x86_64-w64-mingw32-g++'
 ld = 'x86_64-w64-mingw32-ld'
 objcopy = 'x86_64-w64-mingw32-objcopy'
+objdump = 'x86_64-w64-mingw32-objdump'
 # Fedora's ${build_host}-pkg-config clobbers search paths; avoid it
 pkgconfig = 'pkg-config'
 strip = 'x86_64-w64-mingw32-strip'


### PR DESCRIPTION
Detect if a dependency's static library improperly uses `dllexport`.