### PR TITLE
workflows: periodically check for updates

### DIFF
--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -1,0 +1,92 @@
+# Check for updated dependencies
+
+name: Updates - check
+
+on:
+  push:
+    branches: [main]
+    paths: ['meson/subprojects/*.wrap']
+  schedule:
+    - cron: '0 12 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: none
+
+env:
+  GIT_BRANCH: update-${{ github.repository_owner }}
+  GIT_NAME: OpenSlide Automation
+  GIT_EMAIL: openslide@openslide.org
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
+      - name: Get bot username
+        id: user
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
+        run: echo "username=$(gh api user -q .login)" >> $GITHUB_OUTPUT
+      - name: Update wraps
+        id: modified
+        run: |
+          pip install --user meson
+          meson wrap update --sourcedir meson
+          modified=$(git status --porcelain "meson/subprojects/*.wrap" |
+                  sed -e 's:.*/::' -e 's/\.wrap$//')
+          modified=$(echo $modified | sed -e 's/ /, /g')
+          echo "modified=$modified" >> $GITHUB_OUTPUT
+      - name: Post updated wraps
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
+          author: "${{ env.GIT_NAME }} <${{ env.GIT_EMAIL }}>"
+          committer: "${{ env.GIT_NAME }} <${{ env.GIT_EMAIL }}>"
+          add-paths: "meson/subprojects/*.wrap"
+          branch: ${{ env.GIT_BRANCH }}
+          commit-message: Update ${{ steps.modified.outputs.modified }}
+          signoff: true
+          title: Update ${{ steps.modified.outputs.modified }}
+          body: "<!-- topic=dependencies -->"
+          push-to-fork: ${{ steps.user.outputs.username }}/${{ github.event.repository.name }}
+          delete-branch: true
+      - name: Check for stale dependencies
+        run: |
+          git checkout ${{ env.GIT_BRANCH }}
+          ./build.sh updates | tee stale-report
+      - name: File issue for stale dependencies
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
+        run: |
+          issue=$(gh issue list -A "${{ steps.user.outputs.username }}" \
+              -s open -S 'topic=dependencies in:body' --json number \
+              -q .[0].number)
+          stale=$(awk '{print $1}' stale-report | sort)
+          stale=$(echo $stale | sed -e 's/ /, /g')
+          if [ -n "$stale" ]; then
+              title="Update $stale upstream"
+              body="These wraps need updating in \
+          [wrapdb](https://github.com/mesonbuild/wrapdb), or in this repo if \
+          not imported from wrapdb:
+
+          \`\`\`
+          $(cat stale-report)
+          \`\`\`
+
+          <!-- topic=dependencies -->"
+              if [ -z "$issue" ]; then
+                  echo "Creating issue..."
+                  gh issue create -b "$body" -t "$title"
+              else
+                  echo "Updating issue..."
+                  gh issue edit "$issue" -b "$body" -t "$title"
+              fi
+          elif [ -n "$issue" ]; then
+              gh issue close "$issue" -r completed \
+                  -c "Everything looks up-to-date now."
+          fi

--- a/.github/workflows/update-label.yml
+++ b/.github/workflows/update-label.yml
@@ -1,0 +1,58 @@
+# Privileged workflow to label issues and PRs for dependency updates
+
+name: Updates - label
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    branches: [main]
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+env:
+  GH_LABEL: update
+
+jobs:
+  label-update:
+    name: Label update
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get bot username
+        id: user
+        env:
+          GITHUB_TOKEN: ${{ secrets.OPENSLIDE_BOT_TOKEN }}
+        run: echo "username=$(gh api user -q .login)" >> $GITHUB_OUTPUT
+      - name: Add label
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.actor }}" != "${{ steps.user.outputs.username }}" ]
+          then
+              echo "Actor isn't bot; exiting"
+              exit 0
+          fi
+          case "${{ github.event_name }}" in
+          issues)
+              found=${{ contains(github.event.issue.body, 'topic=dependencies') }}
+              if [ "$found" = true ]; then
+                  gh issue edit -R "${{ github.repository }}" \
+                      "${{ github.event.issue.number }}" \
+                      --add-label $GH_LABEL
+              fi
+              ;;
+          pull_request_target)
+              found=${{ contains(github.event.pull_request.body, 'topic=dependencies') }}
+              if [ "$found" = true ]; then
+                  gh pr edit -R "${{ github.repository }}" \
+                      "${{ github.event.number }}" \
+                      --add-label $GH_LABEL
+              fi
+              ;;
+          *)
+              echo "Unknown event: ${{ github.event_name }}"
+              exit 1
+          esac

--- a/build.sh
+++ b/build.sh
@@ -528,9 +528,6 @@ do
 done
 shift $(( $OPTIND - 1 ))
 
-# Probe build environment
-probe
-
 # Clean up any prior Meson overrides, since various subcommands want to
 # read wrap files
 (
@@ -541,12 +538,15 @@ probe
 # Process command-line arguments
 case "$1" in
 sdist)
+    probe
     sdist
     ;;
 bdist)
+    probe
     bdist
     ;;
 clean)
+    probe
     shift
     clean "$@"
     ;;


### PR DESCRIPTION
Automatically check for updates once a week, whenever wraps are updated, or on demand.  Have @openslide-bot maintain a PR with updates from wrapdb, and an issue for any remaining updates reported by `./build.sh updates`.

We need to do this in the context of @openslide-bot, rather than the `GITHUB_TOKEN`, because PRs created by the `GITHUB_TOKEN` can't put their head branch in a fork, and don't automatically run CI.  However, we want to label the issues and PRs, which would require giving @openslide-bot permissions on the repo.  Instead, we have a second, privileged workflow to detect and label these issues/PRs.

Since the workflow maintains the PR branch in @openslide-bot's fork, which may have a stale main branch with different Actions workflows, the bot token must have the `workflow` scope to allow updating workflows in the branch.  Workflows have been disabled in the fork to minimize the effects.

To support this, allow the `./build.sh updates` command to run without a suitable cross-compiler available.