### PR TITLE
builder: add flag file noting the identity of the container image

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -1,4 +1,5 @@
 FROM docker.io/gentoo/stage3:latest
+RUN touch /etc/openslide-winbuild-builder-v1
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
 COPY package.accept_keywords /etc/portage/package.accept_keywords/cross
 COPY package.use /etc/portage/package.use/cross


### PR DESCRIPTION
In practice, `build.sh` now expects to run in the specific container image we ship; we're not going to support other build environments.  Make that explicit by adding a flag file that `build.sh` can check for.  Include a version number, which we can increment if we substantially change the image's functionality in future.

The `build.sh` side will be added in a followup after the image is rebuilt.