### PR TITLE
workflows: move scheduled container rebuild into this repo

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,9 +9,9 @@ on:
   pull_request:
     branches: [main]
     paths: [builder/*]
+  schedule:
+    - cron: "40 14 1 * *"
   workflow_dispatch:
-  # openslide/builds invokes this from a scheduled build
-  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/update-check.yml
+++ b/.github/workflows/update-check.yml
@@ -1,6 +1,6 @@
 # Check for updated dependencies
 
-name: Updates - check
+name: Check for updates
 
 on:
   push:

--- a/.github/workflows/update-label.yml
+++ b/.github/workflows/update-label.yml
@@ -1,6 +1,6 @@
 # Privileged workflow to label issues and PRs for dependency updates
 
-name: Updates - label
+name: Label
 
 on:
   issues:
@@ -18,7 +18,7 @@ env:
 
 jobs:
   label-update:
-    name: Label update
+    name: Add labels
     runs-on: ubuntu-latest
     steps:
       - name: Get bot username


### PR DESCRIPTION
The container rebuild workflow has always lived here, but the scheduled rebuild has historically run from the [openslide/builds](https://github.com/openslide/builds) repo.  The sole reason for this indirection is that openslide/builds has logic to keep the repository active, so GitHub doesn't disable scheduled jobs after 60 days of inactivity.  Now that we have periodic update-checking in this repo, we have that problem here anyway (https://github.com/openslide/openslide-winbuild/issues/144).  Move the timer out of openslide/builds to simplify.

While we're here, clarify the names of the update-checking workflows.