### PR TITLE
Drop redundant `-mms-bitfields` compiler option

### DIFF
--- a/meson/cross-win32.ini
+++ b/meson/cross-win32.ini
@@ -1,8 +1,8 @@
 [built-in options]
 prefix = '/'
-c_args = ['-O2', '-g', '-mms-bitfields', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3', '-msse2', '-mfpmath=sse', '-mstackrealign']
+c_args = ['-O2', '-g', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3', '-msse2', '-mfpmath=sse', '-mstackrealign']
 c_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base', '-Wl,--dynamicbase', '-Wl,--nxcompat']
-cpp_args = ['-O2', '-g', '-mms-bitfields', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3', '-msse2', '-mfpmath=sse', '-mstackrealign']
+cpp_args = ['-O2', '-g', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3', '-msse2', '-mfpmath=sse', '-mstackrealign']
 cpp_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base', '-Wl,--dynamicbase', '-Wl,--nxcompat']
 pkg_config_path = ''
 

--- a/meson/cross-win64.ini
+++ b/meson/cross-win64.ini
@@ -1,8 +1,8 @@
 [built-in options]
 prefix = '/'
-c_args = ['-O2', '-g', '-mms-bitfields', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
+c_args = ['-O2', '-g', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
 c_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base', '-Wl,--dynamicbase', '-Wl,--nxcompat']
-cpp_args = ['-O2', '-g', '-mms-bitfields', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
+cpp_args = ['-O2', '-g', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
 cpp_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base', '-Wl,--dynamicbase', '-Wl,--nxcompat']
 pkg_config_path = ''
 


### PR DESCRIPTION
It's been the default [since GCC 4.7](https://gcc.gnu.org/gcc-4.7/changes.html).