### PR TITLE
Drop redundant compiler/linker options

### DIFF
--- a/meson/cross-win32.ini
+++ b/meson/cross-win32.ini
@@ -1,9 +1,9 @@
 [built-in options]
 prefix = '/'
-c_args = ['-O2', '-g', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3', '-msse2', '-mfpmath=sse', '-mstackrealign']
-c_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base', '-Wl,--dynamicbase', '-Wl,--nxcompat']
-cpp_args = ['-O2', '-g', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3', '-msse2', '-mfpmath=sse', '-mstackrealign']
-cpp_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base', '-Wl,--dynamicbase', '-Wl,--nxcompat']
+c_args = ['-O2', '-g', '-fexceptions', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3', '-msse2', '-mfpmath=sse', '-mstackrealign']
+c_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base']
+cpp_args = ['-O2', '-g', '-fexceptions', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3', '-msse2', '-mfpmath=sse', '-mstackrealign']
+cpp_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base']
 pkg_config_path = ''
 
 [properties]

--- a/meson/cross-win64.ini
+++ b/meson/cross-win64.ini
@@ -1,9 +1,9 @@
 [built-in options]
 prefix = '/'
-c_args = ['-O2', '-g', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
-c_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base', '-Wl,--dynamicbase', '-Wl,--nxcompat']
-cpp_args = ['-O2', '-g', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
-cpp_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base', '-Wl,--dynamicbase', '-Wl,--nxcompat']
+c_args = ['-O2', '-g', '-fexceptions', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
+c_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base']
+cpp_args = ['-O2', '-g', '-fexceptions', '-fstack-protector-strong', '-U_FORTIFY_SOURCE', '-D_FORTIFY_SOURCE=3']
+cpp_link_args = ['-static-libgcc', '-Wl,--enable-auto-image-base']
 pkg_config_path = ''
 
 [properties]


### PR DESCRIPTION
GCC &ge; 12 enables `-ftree-vectorize` by default.  binutils &ge; 2.36 enables `--dynamicbase` and `--nxcompat` by default.