### PR TITLE
Add native file for Linux build

### DIFF
--- a/.github/find-container-digest/action.yml
+++ b/.github/find-container-digest/action.yml
@@ -5,7 +5,8 @@ name: Find builder container digest
 description: Get repo and image digest of the OpenSlide builder container
 inputs:
   builder_image:
-    description: Docker image reference of the builder container
+    description: |
+      Docker image reference of the builder container, or "windows" or "linux"
     required: false
     type: string
 outputs:
@@ -20,8 +21,11 @@ runs:
       shell: bash
       run: |
         repo=$(cut -f1 -d: <<<"${{ inputs.builder_image }}")
-        repo="${repo:-ghcr.io/openslide/winbuild-builder}"
-        label=$(cut -f2 -d: <<<"${{ inputs.builder_image }}")
+        case "$repo" in
+        windows|"") repo=ghcr.io/openslide/winbuild-builder ;;
+        linux) repo=ghcr.io/openslide/linux-builder ;;
+        esac
+        label=$(cut -f2 -d: -s <<<"${{ inputs.builder_image }}")
         label="${label:-latest}"
         digest=$(skopeo inspect "docker://${repo}:${label}" | jq -r .Digest)
         ref="${repo}@${digest}"

--- a/.github/workflows/direct.yml
+++ b/.github/workflows/direct.yml
@@ -1,0 +1,42 @@
+# Temporary workflow to build Linux binaries directly with Meson
+
+name: Direct
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  linux:
+    name: Linux
+    runs-on: ubuntu-latest
+    container: ghcr.io/openslide/linux-builder:latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+      - name: Cache sources
+        uses: actions/cache@v3
+        with:
+          key: direct-cache
+          path: meson/subprojects/packagecache
+      - name: Build
+        working-directory: meson
+        run: |
+          meson setup build --buildtype plain --wrap-mode nofallback \
+              --native-file native-linux-amd64.ini \
+              -Dopenslide:werror=true -Dopenslide-java:werror=true
+          meson compile -C build
+          DESTDIR=install meson install -C build
+          mkdir output
+          cp build/install/{bin/slidetool,lib64/libopenslide.so.1} output/
+          patchelf --set-rpath '$ORIGIN' output/slidetool
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: linux
+          path: meson/output

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Find builder container digest
         id: find
         uses: ./.github/find-container-digest
+        with:
+          builder_image: windows
       - name: Calculate parameters
         id: params
         run: echo "pkgver=main-$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Find builder container digest
         id: find
         uses: ./.github/find-container-digest
+        with:
+          builder_image: windows
       - name: Calculate parameters
         id: params
         run: echo "pkgver=pr-${{ github.event.number }}.${{ github.run_number }}.${{ github.run_attempt }}-$(echo ${{ github.sha }} | cut -c-7)" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Find builder container digest
         id: find
         uses: ./.github/find-container-digest
+        with:
+          builder_image: windows
       - name: Calculate parameters
         id: params
         run: echo "pkgver=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -50,6 +50,7 @@ subproject(
   'glib',
   default_options : [
     'nls=disabled',
+    'tests=false',
   ],
 )
 subproject(

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -60,6 +60,8 @@ subproject(
     'jpeg=disabled',
     'man=false',
     'builtin_loaders=bmp',
+    'introspection=disabled',
+    'gio_sniffing=false',
     'installed_tests=false',
   ],
 )

--- a/meson/native-linux-amd64.ini
+++ b/meson/native-linux-amd64.ini
@@ -1,0 +1,10 @@
+[built-in options]
+prefix = '/'
+c_args = ['-O2', '-g', '-fpic', '-fstack-clash-protection', '-fcf-protection=full', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
+c_link_args = ['-fcf-protection=full', '-Wl,-z,relro', '-Wl,-z,now']
+cpp_args = ['-O2', '-g', '-fpic', '-fstack-clash-protection', '-fcf-protection=full', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
+cpp_link_args = ['-fcf-protection=full', '-Wl,-z,relro', '-Wl,-z,now']
+pkg_config_path = ''
+
+[properties]
+pkg_config_libdir = '/native/lib/pkgconfig'


### PR DESCRIPTION
and a temporary GitHub Actions workflow to exercise it.  Allow specifying `windows` or `linux` to the `find-container-images` action.