### PR TITLE
Handle `buildtype`, `wrap_mode`, and OpenSlide `werror` in `meson.build`

### DIFF
--- a/.github/workflows/direct.yml
+++ b/.github/workflows/direct.yml
@@ -28,7 +28,7 @@ jobs:
         working-directory: meson
         run: |
           meson setup build --native-file native-linux-x86_64.ini \
-              -Dopenslide:werror=true -Dopenslide-java:werror=true
+              -Dopenslide_werror=true
           meson compile -C build
           DESTDIR=install meson install -C build
           mkdir output
@@ -67,7 +67,7 @@ jobs:
         run: |
           for arch in x86_64 arm64; do
               meson setup $arch --cross-file cross-macos-${arch}.ini \
-                  -Dopenslide:werror=true -Dopenslide-java:werror=true
+                  -Dopenslide_werror=true
               meson compile -C $arch
               DESTDIR=install meson install -C $arch
           done

--- a/.github/workflows/direct.yml
+++ b/.github/workflows/direct.yml
@@ -27,8 +27,7 @@ jobs:
       - name: Build
         working-directory: meson
         run: |
-          meson setup build --buildtype plain --wrap-mode nofallback \
-              --native-file native-linux-x86_64.ini \
+          meson setup build --native-file native-linux-x86_64.ini \
               -Dopenslide:werror=true -Dopenslide-java:werror=true
           meson compile -C build
           DESTDIR=install meson install -C build
@@ -67,8 +66,7 @@ jobs:
         working-directory: meson
         run: |
           for arch in x86_64 arm64; do
-              meson setup $arch --buildtype plain --wrap-mode nofallback \
-                  --cross-file cross-macos-${arch}.ini \
+              meson setup $arch --cross-file cross-macos-${arch}.ini \
                   -Dopenslide:werror=true -Dopenslide-java:werror=true
               meson compile -C $arch
               DESTDIR=install meson install -C $arch

--- a/build.sh
+++ b/build.sh
@@ -209,9 +209,7 @@ build() {
     fi
     if [ ! -d "$build" ]; then
         meson setup \
-                --buildtype plain \
                 --cross-file "${cross_file}" \
-                --wrap-mode nofallback \
                 "$build" meson \
                 ${ver_suffix:+-Dversion_suffix=${ver_suffix}} \
                 ${openslide_werror:+-Dopenslide:werror=true} \

--- a/build.sh
+++ b/build.sh
@@ -212,8 +212,7 @@ build() {
                 --cross-file "${cross_file}" \
                 "$build" meson \
                 ${ver_suffix:+-Dversion_suffix=${ver_suffix}} \
-                ${openslide_werror:+-Dopenslide:werror=true} \
-                ${openslide_werror:+-Dopenslide-java:werror=true}
+                ${openslide_werror}
     fi
     meson compile -C "$build" $parallel
     # When building multiple interdependent subpackages, we need to make sure
@@ -474,7 +473,7 @@ do
         ver_suffix="${OPTARG}"
         ;;
     w)
-        openslide_werror=1
+        openslide_werror="-Dopenslide_werror=true"
         ;;
     esac
 done

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -4,7 +4,9 @@ project(
   license : 'LGPL-2.1-only',
   meson_version : '>=0.64',
   default_options : [
+    'buildtype=plain',
     'default_library=static',
+    'wrap_mode=nofallback',
   ],
 )
 

--- a/meson/meson.build
+++ b/meson/meson.build
@@ -140,6 +140,12 @@ subproject(
     'default_library=shared',
     'doc=disabled',
     'version_suffix=' + get_option('version_suffix'),
+    'werror=' + get_option('openslide_werror').to_string(),
   ],
 )
-subproject('openslide-java')
+subproject(
+  'openslide-java',
+  default_options : [
+    'werror=' + get_option('openslide_werror').to_string(),
+  ],
+)

--- a/meson/meson_options.txt
+++ b/meson/meson_options.txt
@@ -1,4 +1,10 @@
 option(
+  'openslide_werror',
+  type : 'boolean',
+  value : false,
+  description : 'Fail on compile warnings from OpenSlide/OpenSlide Java',
+)
+option(
   'version_suffix',
   type : 'string',
   description : 'Suffix to append to the OpenSlide version string',


### PR DESCRIPTION
We always want `buildtype=plain` and `wrap_mode=nofallback`.  Set them in `meson.build` so manual Meson invocations don't need to do it.  Also, add an `openslide_werror` Meson option so `build.sh` or manual Meson builds don't need to know how to pass `werror` options directly to the OpenSlide and OpenSlide Java subprojects.