### PR TITLE
workflows: stop including Git main of OpenSlide Java in PR CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -67,8 +67,6 @@ jobs:
       macos_enable: true
       openslide_repo: openslide/openslide
       openslide_ref: main
-      openslide_java_repo: openslide/openslide-java
-      openslide_java_ref: main
       openslide_bin_repo: ${{ github.repository }}
       openslide_bin_ref: ${{ github.ref }}
       suffix: ${{ needs.setup.outputs.suffix }}.git


### PR DESCRIPTION
https://github.com/openslide/openslide-java/pull/71 drops the platform-specific shared library from OpenSlide Java.  Accordingly, it removes the `embed_jni_path` build option, which we still need to use when building the latest release.

Without platform-specific code, there won't be a need to ship future OpenSlide Java releases here.  For now, continue shipping the latest release and retain the ability to override it, but stop overriding with Git main when testing PRs.

For: https://github.com/openslide/openslide-bin/issues/239