### PR TITLE
builder: bump API for Meson >= 1.10.0

### DIFF
--- a/bintool
+++ b/bintool
@@ -50,8 +50,8 @@ from common.meson import (
 )
 from common.software import Project
 
-WINDOWS_API_VERS = (7,)
-LINUX_API_VERS = (6,)
+WINDOWS_API_VERS = (7, 8)
+LINUX_API_VERS = (6, 7)
 # we have a higher minimum than the underlying meson.build
 MESON_MIN_VER = (1, 5, 0)
 

--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/almalinuxorg/almalinux:8
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-linux-builder-v{5,6}
+RUN touch /etc/openslide-linux-builder-v7
 RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled powertools && \

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/gentoo/stage3:latest
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-winbuild-builder-v{6,7}
+RUN touch /etc/openslide-winbuild-builder-v8
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
 COPY package.accept_keywords /etc/portage/package.accept_keywords/openslide
 COPY package.use /etc/portage/package.use/openslide


### PR DESCRIPTION
The 4.0.0.10 source tarball (only) fails to build with Meson 1.10.0 due to a Meson bug.  d91ccc3d fixed this, but we should bump the API to avoid confusion.