### PR TITLE
Revert "builder: revert API versions for Meson 1.10.1"

### DIFF
--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/almalinuxorg/almalinux:8
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-linux-builder-v{5,6}  # v7 obsoleted; skip it
+RUN touch /etc/openslide-linux-builder-v7
 RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled powertools && \

--- a/builder/windows/Dockerfile
+++ b/builder/windows/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/gentoo/stage3:latest
 # NOTE: try to keep the current container image compatible with the latest
 # stable source release, so people can conveniently build from the source
 # tarball
-RUN touch /etc/openslide-winbuild-builder-v{6,7}  # v8 obsoleted; skip it
+RUN touch /etc/openslide-winbuild-builder-v8
 RUN echo 'FEATURES="-sandbox -usersandbox -ipc-sandbox -network-sandbox -pid-sandbox"' >> /etc/portage/make.conf
 COPY package.accept_keywords /etc/portage/package.accept_keywords/openslide
 COPY package.use /etc/portage/package.use/openslide


### PR DESCRIPTION
Meson 1.10.1 fixes the regression on x86_64 but not on aarch64; see https://github.com/mesonbuild/meson/issues/15544.

This reverts #427.