### PR TITLE
builder/linux: add zstd

### DIFF
--- a/builder/linux/Dockerfile
+++ b/builder/linux/Dockerfile
@@ -8,6 +8,6 @@ RUN dnf -y upgrade && \
     dnf -y install 'dnf-command(config-manager)' epel-release && \
     dnf config-manager --set-enabled powertools && \
     dnf -y install gcc-c++ git-core nasm ninja-build patchelf \
-    python3.12-pip && \
+    python3.12-pip zstd && \
     dnf clean all
 RUN pip3 install auditwheel license-expression meson


### PR DESCRIPTION
Allow unpacking zstd-compressed build overrides inside the container.

Don't bump the API version because bintool doesn't need this.  CI workflows do, and they always use latest.