### PR TITLE
Fix corrupt partial bottom tile row on non-JPEG, non-JP2K TIFF levels

### DIFF
--- a/subprojects/openslide.wrap
+++ b/subprojects/openslide.wrap
@@ -7,4 +7,5 @@ source_filename = openslide-4.0.0.tar.xz
 source_hash = cc227c44316abb65fb28f1c967706eb7254f91dbfab31e9ae6a48db6cf4ae562
 
 # https://github.com/openslide/openslide/pull/534
-diff_files = openslide-bdist.patch
+# https://github.com/openslide/openslide/pull/706
+diff_files = openslide-bdist.patch, openslide-libtiff.patch

--- a/subprojects/packagefiles/openslide-libtiff.patch
+++ b/subprojects/packagefiles/openslide-libtiff.patch
@@ -1,0 +1,20 @@
+diff --git a/src/openslide-decode-tiff.c b/src/openslide-decode-tiff.c
+index 1988bd7d4879..9364639bf95d 100644
+--- a/src/openslide-decode-tiff.c
++++ b/src/openslide-decode-tiff.c
+@@ -303,9 +303,14 @@ bool _openslide_tiff_read_tile(struct _openslide_tiff_level *tiffl,
+     _openslide_performance_warn_once(&tiffl->warned_read_indirect,
+                                      "Using slow libtiff read path for "
+                                      "directory %d", tiffl->dir);
++    // artificially limit dest height so libtiff 4.7.1 won't unpad the
++    // bottom row of tiles into the bottom pixels of dest
++    // https://gitlab.com/libtiff/libtiff/-/issues/791
++    uint32_t clipped_h =
++      MIN(tiffl->tile_h, MAX(tiffl->image_h - tile_row * tiffl->tile_h, 0));
+     return tiff_read_region(tiff, dest,
+                             tile_col * tiffl->tile_w, tile_row * tiffl->tile_h,
+-                            tiffl->tile_w, tiffl->tile_h, err);
++                            tiffl->tile_w, clipped_h, err);
+   }
+ }
+ 


### PR DESCRIPTION
Work around libtiff 4.7.1 regression affecting openslide-bin 4.0.0.9 and above.

Fixes: https://github.com/openslide/openslide-bin/issues/433