### PR TITLE
libdicom: improve `dcm_filehandle_get_frame_number()` performance

### DIFF
--- a/subprojects/libdicom.wrap
+++ b/subprojects/libdicom.wrap
@@ -6,5 +6,8 @@ source_hash = 7a448d295b179a4c0b311c09f5253655446a44bf66b3b7d2aa4c09d15f02f1f8
 source_fallback_url = https://wrapdb.mesonbuild.com/v2/libdicom_1.2.1-1/get_source/libdicom-1.2.1.tar.xz
 wrapdb_version = 1.2.1-1
 
+# https://github.com/ImagingDataCommons/libdicom/pull/116
+diff_files = libdicom-preallocated-error.patch
+
 [provide]
 dependency_names = libdicom

--- a/subprojects/packagefiles/libdicom-preallocated-error.patch
+++ b/subprojects/packagefiles/libdicom-preallocated-error.patch
@@ -1,0 +1,95 @@
+DCM_ERROR_CODE_MISSING_FRAME is unusual: it's returned by one function,
+which might be called in a tight loop by an application checking which
+frames are available in a DcmFilehandle.  As such, we don't want to incur
+allocation and string-formatting overhead each time a frame is missing.
+Return a generic preallocated DcmError instead, and ensure
+dcm_error_free() doesn't free it.
+
+diff --git a/src/dicom-file.c b/src/dicom-file.c
+index 59d3f4f67191..6624244a4431 100644
+--- a/src/dicom-file.c
++++ b/src/dicom-file.c
+@@ -1431,18 +1431,16 @@ bool dcm_filehandle_get_frame_number(DcmError **error,
+     if (filehandle->layout == DCM_LAYOUT_SPARSE) {
+         index = filehandle->frame_index[index];
+         if (index == 0xffffffff) {
+-            dcm_error_set(error, DCM_ERROR_CODE_MISSING_FRAME,
+-                          "no frame",
+-                          "no frame at position (%u, %u)", column, row);
++            // we might return this error hundreds of thousands of times;
++            // avoid allocating each time
++            dcm_error_set_static(error, &DCM_STATIC_ERROR_MISSING_FRAME);
+             return false;
+         }
+     } else {
+         // subtract the start of this file, for catenation support
+         index -= filehandle->frame_offset;
+         if (index < 0 || index >= (int64_t) filehandle->num_frames) {
+-            dcm_error_set(error, DCM_ERROR_CODE_MISSING_FRAME,
+-                          "no frame",
+-                          "no frame at position (%u, %u)", column, row);
++            dcm_error_set_static(error, &DCM_STATIC_ERROR_MISSING_FRAME);
+             return false;
+         }
+     }
+diff --git a/src/dicom.c b/src/dicom.c
+index b66b46b901c6..c63b29c5fb43 100644
+--- a/src/dicom.c
++++ b/src/dicom.c
+@@ -186,11 +186,19 @@ struct _DcmError {
+     DcmErrorCode code;
+     char *summary;
+     char *message;
++    bool is_static;
++};
++
++const DcmError DCM_STATIC_ERROR_MISSING_FRAME = {
++    .code = DCM_ERROR_CODE_MISSING_FRAME,
++    .summary = "no frame",
++    .message = "no frame at this position",
++    .is_static = true,
+ };
+ 
+ static void dcm_error_free(DcmError *error)
+ {
+-    if (error) {
++    if (error && !error->is_static) {
+         free(error->summary);
+         error->summary = NULL;
+         free(error->message);
+@@ -252,6 +260,18 @@ void dcm_error_set(DcmError **error, DcmErrorCode code,
+ }
+ 
+ 
++void dcm_error_set_static(DcmError **error, const DcmError *static_error) {
++    if (!static_error->is_static) {
++        dcm_log_critical("DcmError is not static");
++    } else if (error && *error) {
++        dcm_log_critical("DcmError set twice");
++    } else if (error) {
++        *error = (DcmError *) static_error;
++    }
++    /* otherwise don't log; we're in a fast path */
++}
++
++
+ void dcm_error_clear(DcmError **error)
+ {
+     if (error) {
+diff --git a/src/pdicom.h b/src/pdicom.h
+index 0a0bbef4b226..bcafceabacac 100644
+--- a/src/pdicom.h
++++ b/src/pdicom.h
+@@ -65,6 +65,9 @@ char *dcm_printf_append(char *str, const char *format, ...);
+ 
+ void dcm_free_string_array(char **strings, int n);
+ 
++extern const DcmError DCM_STATIC_ERROR_MISSING_FRAME;
++void dcm_error_set_static(DcmError **error, const DcmError *static_error);
++
+ size_t dcm_dict_vr_size(DcmVR vr);
+ uint32_t dcm_dict_vr_capacity(DcmVR vr);
+ int dcm_dict_vr_header_length(DcmVR vr);
+-- 
+2.54.0
+


### PR DESCRIPTION
when the frame is missing.