### PR TITLE
machines: strip dead code on Linux and macOS

### DIFF
--- a/machines/cross-macos-arm64.ini
+++ b/machines/cross-macos-arm64.ini
@@ -1,11 +1,11 @@
 [built-in options]
 prefix = '/'
 c_args = ['-O2', '-g', '-fstack-protector-strong', '--target=aarch64-apple-macosx11']
-c_link_args = ['--target=aarch64-apple-macosx11', '-Wl,-exported_symbol,_openslide_*']
+c_link_args = ['--target=aarch64-apple-macosx11', '-Wl,-dead_strip', '-Wl,-exported_symbol,_openslide_*']
 cpp_args = ['-O2', '-g', '-fstack-protector-strong', '--target=aarch64-apple-macosx11']
-cpp_link_args = ['--target=aarch64-apple-macosx11', '-Wl,-exported_symbol,_openslide_*']
+cpp_link_args = ['--target=aarch64-apple-macosx11', '-Wl,-dead_strip', '-Wl,-exported_symbol,_openslide_*']
 objc_args = ['-O2', '-g', '-fstack-protector-strong', '--target=aarch64-apple-macosx11']
-objc_link_args = ['--target=aarch64-apple-macosx11', '-Wl,-exported_symbol,_openslide_*']
+objc_link_args = ['--target=aarch64-apple-macosx11', '-Wl,-dead_strip', '-Wl,-exported_symbol,_openslide_*']
 pkg_config_path = ''
 
 [properties]

--- a/machines/cross-macos-x86_64.ini
+++ b/machines/cross-macos-x86_64.ini
@@ -1,11 +1,11 @@
 [built-in options]
 prefix = '/'
 c_args = ['-O2', '-g', '-fstack-protector-strong', '--target=x86_64-apple-macosx11']
-c_link_args = ['--target=x86_64-apple-macosx11', '-Wl,-exported_symbol,_openslide_*']
+c_link_args = ['--target=x86_64-apple-macosx11', '-Wl,-dead_strip', '-Wl,-exported_symbol,_openslide_*']
 cpp_args = ['-O2', '-g', '-fstack-protector-strong', '--target=x86_64-apple-macosx11']
-cpp_link_args = ['--target=x86_64-apple-macosx11', '-Wl,-exported_symbol,_openslide_*']
+cpp_link_args = ['--target=x86_64-apple-macosx11', '-Wl,-dead_strip', '-Wl,-exported_symbol,_openslide_*']
 objc_args = ['-O2', '-g', '-fstack-protector-strong', '--target=x86_64-apple-macosx11']
-objc_link_args = ['--target=x86_64-apple-macosx11', '-Wl,-exported_symbol,_openslide_*']
+objc_link_args = ['--target=x86_64-apple-macosx11', '-Wl,-dead_strip', '-Wl,-exported_symbol,_openslide_*']
 pkg_config_path = ''
 
 [properties]

--- a/machines/native-linux-aarch64.ini
+++ b/machines/native-linux-aarch64.ini
@@ -1,9 +1,9 @@
 [built-in options]
 prefix = '/'
-c_args = ['-O2', '-g', '-fpic', '-fstack-clash-protection', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
-c_link_args = ['-Wl,-z,relro', '-Wl,-z,now', '-Wl,--exclude-libs,ALL']
-cpp_args = ['-O2', '-g', '-fpic', '-fstack-clash-protection', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
-cpp_link_args = ['-Wl,-z,relro', '-Wl,-z,now', '-Wl,--exclude-libs,ALL']
+c_args = ['-O2', '-g', '-fpic', '-ffunction-sections', '-fdata-sections', '-fstack-clash-protection', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
+c_link_args = ['-Wl,-z,relro', '-Wl,-z,now', '-Wl,--gc-sections', '-Wl,--exclude-libs,ALL']
+cpp_args = ['-O2', '-g', '-fpic', '-ffunction-sections', '-fdata-sections', '-fstack-clash-protection', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
+cpp_link_args = ['-Wl,-z,relro', '-Wl,-z,now', '-Wl,--gc-sections', '-Wl,--exclude-libs,ALL']
 pkg_config_path = ''
 
 [properties]

--- a/machines/native-linux-x86_64.ini
+++ b/machines/native-linux-x86_64.ini
@@ -1,9 +1,9 @@
 [built-in options]
 prefix = '/'
-c_args = ['-O2', '-g', '-fpic', '-fstack-clash-protection', '-fcf-protection=full', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
-c_link_args = ['-fcf-protection=full', '-Wl,-z,relro', '-Wl,-z,now', '-Wl,--exclude-libs,ALL']
-cpp_args = ['-O2', '-g', '-fpic', '-fstack-clash-protection', '-fcf-protection=full', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
-cpp_link_args = ['-fcf-protection=full', '-Wl,-z,relro', '-Wl,-z,now', '-Wl,--exclude-libs,ALL']
+c_args = ['-O2', '-g', '-fpic', '-ffunction-sections', '-fdata-sections', '-fstack-clash-protection', '-fcf-protection=full', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
+c_link_args = ['-fcf-protection=full', '-Wl,-z,relro', '-Wl,-z,now', '-Wl,--gc-sections', '-Wl,--exclude-libs,ALL']
+cpp_args = ['-O2', '-g', '-fpic', '-ffunction-sections', '-fdata-sections', '-fstack-clash-protection', '-fcf-protection=full', '-fexceptions', '-ftree-vectorize', '-fstack-protector-strong', '-D_FORTIFY_SOURCE=2']
+cpp_link_args = ['-fcf-protection=full', '-Wl,-z,relro', '-Wl,-z,now', '-Wl,--gc-sections', '-Wl,--exclude-libs,ALL']
 pkg_config_path = ''
 
 [properties]


### PR DESCRIPTION
Have the linker remove dead code/data on Linux and macOS, reducing library sizes by ~25% and slidetool sizes by ~69%.  The GCC/binutils options are accepted on MinGW but only reduce binary sizes by 80 KiB for reasons that aren't immediately clear, so skip them on Windows.